### PR TITLE
Fix case-sensitive require paths

### DIFF
--- a/controllers/AvailabilityController.php
+++ b/controllers/AvailabilityController.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../core/AbstractCrudController.php';
+require_once __DIR__ . '/../core/AbstractCRUDController.php';
 
 class AvailabilityController extends AbstractCrudController
 {

--- a/controllers/InstrumentController.php
+++ b/controllers/InstrumentController.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../core/AbstractCrudController.php';
+require_once __DIR__ . '/../core/AbstractCRUDController.php';
 
 class InstrumentController extends AbstractCrudController
 {


### PR DESCRIPTION
## Summary
- fix path to `AbstractCRUDController` in Availability and Instrument controllers so the class loads on case-sensitive systems

## Testing
- `php -l controllers/InstrumentController.php` *(fails: php not installed)*
- `composer --version` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68442e0ad05c832588ca52353c3f34d3